### PR TITLE
Format todo model

### DIFF
--- a/internal/models/todo.go
+++ b/internal/models/todo.go
@@ -21,7 +21,7 @@ var ErrNotFound = errors.New("todo not found")
 // Store provides thread-safe access to to-do items in memory.
 type Store struct {
 	sync.RWMutex
-	todos map[int]*ToDo
+	todos  map[int]*ToDo
 	nextID int
 }
 
@@ -104,11 +104,11 @@ func (s *Store) Delete(id int) error {
 
 // ClearCompleted removes all tasks where Completed==true.
 func (s *Store) ClearCompleted() {
-    s.Lock()
-    defer s.Unlock()
-    for id, todo := range s.todos {
-        if todo.Completed {
-            delete(s.todos, id)
-        }
-    }
+	s.Lock()
+	defer s.Unlock()
+	for id, todo := range s.todos {
+		if todo.Completed {
+			delete(s.todos, id)
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- format `todo.go` to keep consistent indentation

## Testing
- `go test ./...` *(fails: malformed go.sum)*

------
https://chatgpt.com/codex/tasks/task_e_6852949afba8832c9d314cb7f956f611